### PR TITLE
Add idle sound when house needs to be claimed

### DIFF
--- a/IronwoodTracker.js
+++ b/IronwoodTracker.js
@@ -424,6 +424,18 @@ function idlePlaySound() {
     }
 }
 
+function houseClaimPlaySound() {
+    const primaryElements = document.getElementsByClassName("primary");
+    if (primaryElements.length > 0) {
+        for (const element of primaryElements) {
+            if (element.innerText == 'Claim') {
+                idleSound.play();
+                return;
+            }
+        }
+    }
+}
+
 function shareSnapshot() { //Copy formatted list of skill levels to clipboard
     let skillsList = document.getElementsByClassName('scroll custom-scrollbar scroll-margin')[0].childNodes;
     let skillTemp = '';
@@ -623,6 +635,7 @@ function trackerLoop() {
     }
     if (idleAlert == true) {
         idlePlaySound();
+        houseClaimPlaySound();
     }
 }
 


### PR DESCRIPTION
This pull request will play the existing idle sound if the green `Claim` bubble appears next to the House menu option. This is to alert the user that there is some action they need to take with their House.

I reused the existing idle sound, but it may make more sense to add a separate option and sound for tracking House claims. Let me know if you wanted me to do add that for this pull request.